### PR TITLE
remove lock files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 /node_modules
 /.pnp
 .pnp.js
-package-lock.json
-yarn.lock
 
 # testing
 /coverage
@@ -28,6 +26,3 @@ yarn-error.log*
 .next
 
 Icon
-
-package-lock.json
-yarn.lock

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MakoTools is a website containing information, tools, and a lot more to aid you 
 ### How to Set Up Locally
 1. Install node.js and NPM. Follow the instructions [here](https://docs.npmjs.com/cli/v8/configuring-npm/install) depending on your operating system.
 2. Install yarn. In the terminal, run `npm install --global yarn`.
-3. Run `yarn init` to install the required packages to your repository.
+3. Run `yarn install` to install the required packages to your repository.
 4. These next few steps will vary depending on how you want to run the project. Running in **development** mode will allow you to update the project as you update the code. Meanwhile, running in **production** mode will create a build by validating the code of the project and run that build.
 
 #### Running in Production mode


### PR DESCRIPTION
Files like `package-lock.json` and `yarn.lock` are actually important to commit because they keep track of the exact package versions that are installed. Without the lock files, different developers on the same team may install packages with different minor versions and get unexpected behavior: https://dev.to/adamklein/package-lock-json-in-git-or-not-50l5