### PR TITLE
Fixed menu problems for homepage and login

### DIFF
--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -16,8 +16,9 @@ import {
 
 function Layout({
   children: Component,
-  footer = true,
-  sidebar = true,
+  hideFooter = false,
+  hideSidebar = false,
+  hideHeader = false,
   wide = false,
   pageTitle,
   meta,
@@ -49,14 +50,14 @@ function Layout({
           },
         }}
         navbar={
-          sidebar ? (
+          !hideSidebar ? (
             <ErrorBoundary>
               <Sidebar hiddenBreakpoint="xs" hidden={!opened} />
             </ErrorBoundary>
           ) : null
         }
       >
-        <Header pageTitle={pageTitle} />
+        {!hideHeader && <Header pageTitle={pageTitle} />}
         <Paper
           sx={{
             position: "relative",
@@ -85,7 +86,7 @@ function Layout({
             </ErrorBoundary>
           </Container>
         </Paper>
-        {footer ? <Footer wide={wide} textOnly={footerTextOnly} /> : null}
+        {!hideFooter ? <Footer wide={wide} textOnly={footerTextOnly} /> : null}
       </AppShell>
     </ErrorBoundary>
   );

--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -75,5 +75,5 @@ export default NoMatch;
 
 import Layout from "../components/Layout";
 NoMatch.getLayout = function getLayout(page) {
-  return <Layout footer={false}>{page}</Layout>;
+  return <Layout hideFooter>{page}</Layout>;
 };

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -146,5 +146,5 @@ export default Home;
 
 import Layout from "../components/Layout";
 Home.getLayout = function getLayout(page) {
-  return <Layout footerTextOnly>{page}</Layout>;
+  return <Layout hideHeader footerTextOnly>{page}</Layout>;
 };

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -16,6 +16,8 @@ import {
   Image as MantineImage,
 } from "@mantine/core";
 
+import Breadcrumbs from "../components/Layout/Header/Breadcrumbs";
+
 import { useFirebaseUser } from "../services/firebase/user";
 import Banner from "../assets/banner.png";
 import AffiliatesLight from "../assets/Affiliates/affiliates_light.svg?url";
@@ -28,6 +30,7 @@ function Home() {
 
   return (
     <>
+      <Breadcrumbs />
       <Box mt={80} />
       <Image src={Banner} style={{ borderRadius: 0 }} />
       <MantineTitle order={1} mt="sm">

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -146,5 +146,5 @@ export default Home;
 
 import Layout from "../components/Layout";
 Home.getLayout = function getLayout(page) {
-  return <Layout hideHeader footerTextOnly>{page}</Layout>;
+  return <Layout footerTextOnly>{page}</Layout>;
 };

--- a/pages/login/index.jsx
+++ b/pages/login/index.jsx
@@ -16,12 +16,7 @@ function Page() {
     }
   }, [firebaseUser, router]);
 
-  return (
-    <>
-      <Breadcrumbs />
-      <Login />
-    </>
-  );
+  return <Login />;
 }
 
 export default Page;

--- a/pages/login/index.jsx
+++ b/pages/login/index.jsx
@@ -30,7 +30,7 @@ import Layout from "../../components/Layout";
 
 Page.getLayout = function getLayout(page) {
   return (
-    <Layout footer={false} sidebar={false}>
+    <Layout hideHeader hideFooter hideSidebar>
       {page}
     </Layout>
   );

--- a/pages/login/index.jsx
+++ b/pages/login/index.jsx
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
+
 import Login from "../../components/Login";
+import Breadcrumbs from "../../components/Layout/Header/Breadcrumbs";
+
 import { useFirebaseUser } from "../../services/firebase/user";
 import { useRouter } from "next/router";
+
 function Page() {
   const router = useRouter();
   const { firebaseUser } = useFirebaseUser();
@@ -12,7 +16,12 @@ function Page() {
     }
   }, [firebaseUser, router]);
 
-  return <Login />;
+  return (
+    <>
+      <Breadcrumbs />
+      <Login />
+    </>
+  );
 }
 
 export default Page;

--- a/pages/login/index.jsx
+++ b/pages/login/index.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 
 import Login from "../../components/Login";
-import Breadcrumbs from "../../components/Layout/Header/Breadcrumbs";
 
 import { useFirebaseUser } from "../../services/firebase/user";
 import { useRouter } from "next/router";


### PR DESCRIPTION
for #27 and #33 

![image](https://user-images.githubusercontent.com/107583604/179754480-d12c8b9f-e0ab-44bf-ac10-b282520f70a8.png)
burger menu should show up for the homepage without scrolling (the top/bottom margins btwn the menu and the rest of the page is so large... may fix that later)

![image](https://user-images.githubusercontent.com/107583604/179754777-00eba91a-af12-4d50-b6f6-69c058f5441b.png)
added burger menu to login page too... lemme know if i should remove it tho :kaoruplead:

also added hideHeader prop to the layout and applied the prop to the login page to prevent the scrolling menu issue. renamed the footer prop to hideFooter and sidebar prop to hideSidebar to make it more attractive in the code

gonna rename Breadcrumbs too