### PR TITLE
Show readable name in breadcrumb instead of ID

### DIFF
--- a/components/Layout/Header/Breadcrumbs.jsx
+++ b/components/Layout/Header/Breadcrumbs.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import {
@@ -6,7 +6,6 @@ import {
   Anchor,
   Text,
   Group,
-  useMantineTheme,
   Drawer,
   Box,
   MediaQuery,
@@ -15,17 +14,12 @@ import {
 import { IconMenu2 } from "@tabler/icons";
 import Sidebar from "../Sidebar";
 
-function BreadcrumbsApp(props) {
-  const theme = useMantineTheme();
-  const location = useRouter();
-  const [pathnames, setPathnames] = useState(
-    location.asPath.split("/").filter((x) => x)
-  );
-  const [opened, setOpened] = useState(false);
+const defaultGetBreadcrumbs = (path) => path.split("/").filter((x) => x);
 
-  useEffect(() => {
-    setPathnames(location.asPath.split("/").filter((x) => x));
-  }, [location]);
+function BreadcrumbsApp({ getBreadcrumbs = defaultGetBreadcrumbs, ...props }) {
+  const location = useRouter();
+  const [opened, setOpened] = useState(false);
+  const breadcrumbs = getBreadcrumbs(location.asPath);
 
   return (
     <Box px="xs" {...props}>
@@ -77,13 +71,13 @@ function BreadcrumbsApp(props) {
             <Link href="/" passHref>
               <Anchor inherit>Makotools</Anchor>
             </Link>
-            {pathnames.map((value, index) => {
-              const last = index === pathnames.length - 1;
+            {breadcrumbs.map((crumb, index) => {
+              const pathnames = defaultGetBreadcrumbs(location.asPath);
               const to = `/${pathnames.slice(0, index + 1).join("/")}`;
 
               return (
-                <Link key={value} href={to} passHref>
-                  <Anchor inherit>{decodeURIComponent(value)}</Anchor>
+                <Link key={crumb} href={to} passHref>
+                  <Anchor inherit>{decodeURIComponent(crumb)}</Anchor>
                 </Link>
               );
             })}

--- a/components/Layout/Header/index.jsx
+++ b/components/Layout/Header/index.jsx
@@ -1,14 +1,14 @@
-import styled from "styled-components";
 import Breadcrumbs from "./Breadcrumbs";
 import { useWindowScroll } from "@mantine/hooks";
-import { Affix, Transition, useMantineTheme, Header } from "@mantine/core";
+import { Affix, Transition, Header } from "@mantine/core";
 
-function HeaderApp() {
-  const [scroll, scrollTo] = useWindowScroll();
+function HeaderApp({ getBreadcrumbs }) {
+  const [scroll] = useWindowScroll();
+  console.log("HeaderApp", getBreadcrumbs);
   return (
     <Affix
       position={{ top: 0, right: 0 }}
-      sx={{ width: " calc(100% - var(--mantine-navbar-width))", zIndex: 200 }}
+      sx={{ width: "calc(100% - var(--mantine-navbar-width))", zIndex: 200 }}
     >
       <Transition transition="slide-down" mounted={scroll.y > 40}>
         {(transitionStyles) => (
@@ -20,7 +20,9 @@ function HeaderApp() {
             py="sm"
             sx={(theme) => ({ boxShadow: theme.shadows.sm })}
           >
-            <Breadcrumbs sx={{ height: 20 }} />
+            <Breadcrumbs sx={{ height: 20 }} getBreadcrumbs={getBreadcrumbs}>
+              test
+            </Breadcrumbs>
           </Header>
         )}
       </Transition>

--- a/components/Layout/Header/index.jsx
+++ b/components/Layout/Header/index.jsx
@@ -4,7 +4,6 @@ import { Affix, Transition, Header } from "@mantine/core";
 
 function HeaderApp({ getBreadcrumbs }) {
   const [scroll] = useWindowScroll();
-  console.log("HeaderApp", getBreadcrumbs);
   return (
     <Affix
       position={{ top: 0, right: 0 }}
@@ -20,9 +19,7 @@ function HeaderApp({ getBreadcrumbs }) {
             py="sm"
             sx={(theme) => ({ boxShadow: theme.shadows.sm })}
           >
-            <Breadcrumbs sx={{ height: 20 }} getBreadcrumbs={getBreadcrumbs}>
-              test
-            </Breadcrumbs>
+            <Breadcrumbs sx={{ height: 20 }} getBreadcrumbs={getBreadcrumbs} />
           </Header>
         )}
       </Transition>

--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -23,6 +23,7 @@ function Layout({
   pageTitle,
   meta,
   footerTextOnly,
+  getBreadcrumbs,
 }) {
   const location = useRouter();
   const [currentPath, setCurrentPath] = useState(location.pathname);
@@ -57,7 +58,9 @@ function Layout({
           ) : null
         }
       >
-        {!hideHeader && <Header pageTitle={pageTitle} />}
+        {!hideHeader && (
+          <Header pageTitle={pageTitle} getBreadcrumbs={getBreadcrumbs} />
+        )}
         <Paper
           sx={{
             position: "relative",

--- a/components/PageTitle.jsx
+++ b/components/PageTitle.jsx
@@ -1,12 +1,11 @@
-import styled from "styled-components";
 import Breadcrumbs from "./Layout/Header/Breadcrumbs";
 import { Box, Title } from "@mantine/core";
 
-function TitleApp({ title, children, space }) {
+function TitleApp({ title, children, space, getBreadcrumbs }) {
   return (
     <Box sx={{ position: "relative", overflow: "hidden" }}>
       {children}
-      <Breadcrumbs />
+      <Breadcrumbs getBreadcrumbs={getBreadcrumbs} />
       <Title
         order={1}
         mt={space || 64}

--- a/package.json
+++ b/package.json
@@ -122,5 +122,7 @@
         "off"
       ]
     }
-  }
+  },
+  "_comment": "Add empty prettier key in order to override code editor settings while applying all Prettier defaults",
+  "prettier": {}
 }

--- a/pages/cards/[id].page.jsx
+++ b/pages/cards/[id].page.jsx
@@ -18,6 +18,15 @@ function Character({ character, card }) {
   // const character = characters.main.data[characterID];
   const characterLocalizedMain = character.mainLang;
   // console.log(cardsJP);
+
+  const getBreadcrumbs = (path) => {
+    const pathNames = path.split("/");
+    pathNames[
+      pathNames.length - 1
+    ] = `(${cardLocalizedMain.title}) ${characterLocalizedMain.last_name} ${characterLocalizedMain.first_name}`;
+    return pathNames.filter((x) => x);
+  };
+
   return (
     <>
       <Head>
@@ -75,6 +84,7 @@ function Character({ character, card }) {
             </Paper> */}
           </>
         }
+        getBreadcrumbs={getBreadcrumbs}
       ></Title>
       <Group>
         {["normal", "evolution"].map((type) => (
@@ -100,7 +110,7 @@ function Character({ character, card }) {
 
 export default Character;
 
-export async function getServerSideProps({ req, res, locale }) {
+export async function getServerSideProps({ res, locale, params }) {
   res.setHeader(
     "Cache-Control",
     "public, s-maxage=7200, stale-while-revalidate=172800"
@@ -110,15 +120,12 @@ export async function getServerSideProps({ req, res, locale }) {
   const cards = await getLocalizedData("cards", locale);
   const characters = await getLocalizedData("characters", locale);
   // const { data: cardsJP } = await getData("cards", "ja");
-  const urlSegments = req.url.split("/");
-  const lastURLSegment = decodeURIComponent(urlSegments[urlSegments.length - 1])
-    .toLocaleLowerCase()
-    .trim();
+  const lastURLSegment = params.id.toLocaleLowerCase();
   const cardID = parseInt(lastURLSegment, 10);
   const cardIndex = cards.main.data.indexOf(
     cards.main.data.find(
       isNaN(cardID)
-        ? (item) => `${item.title}`.toLocaleLowerCase() === lastURLSegment
+        ? (item) => item.title.toLocaleLowerCase() === lastURLSegment
         : (item) => item.id === cardID
     )
   );

--- a/pages/characters/[id].page.jsx
+++ b/pages/characters/[id].page.jsx
@@ -116,5 +116,10 @@ export async function getServerSideProps({ req, res, locale }) {
 }
 
 Character.getLayout = function getLayout(page) {
-  return <Layout>{page}</Layout>;
+  const character = page.props.character;
+  const getBreadcrumbs = (path) => {
+    console.log("PATH", path);
+    return path.split("/").filter((x) => x);
+  };
+  return <Layout getBreadcrumbs={getBreadcrumbs}>{page}</Layout>;
 };

--- a/pages/characters/[id].page.jsx
+++ b/pages/characters/[id].page.jsx
@@ -6,6 +6,14 @@ import ImageViewer from "../../components/core/ImageViewer";
 import { Text, Box } from "@mantine/core";
 
 function Character({ character }) {
+  const getBreadcrumbs = (path) => {
+    const pathNames = path.split("/");
+    pathNames[
+      pathNames.length - 1
+    ] = `${character.first_name} ${character.last_name}`;
+    return pathNames.filter((x) => x);
+  };
+
   return (
     <>
       <Head>
@@ -40,6 +48,7 @@ function Character({ character }) {
           </>
         }
         space={192}
+        getBreadcrumbs={getBreadcrumbs}
       >
         <Box
           sx={{
@@ -77,7 +86,7 @@ function Character({ character }) {
 
 export default Character;
 
-export async function getServerSideProps({ req, res, locale }) {
+export async function getServerSideProps({ res, locale, params }) {
   res.setHeader(
     "Cache-Control",
     "public, s-maxage=7200, stale-while-revalidate=172800"
@@ -85,10 +94,7 @@ export async function getServerSideProps({ req, res, locale }) {
   // refresh every 2 hours, stale for 48hrs
   const characters = await getLocalizedData("characters", locale);
   const { data: charactersEN } = await getData("characters", "en");
-  const urlSegments = req.url.split("/");
-  const lastSegment = decodeURIComponent(urlSegments[urlSegments.length - 1])
-    .toLocaleLowerCase()
-    .trim();
+  const lastSegment = params.id.toLocaleLowerCase();
   const characterID = parseInt(lastSegment, 10);
   const isName = isNaN(characterID);
   const characterIndex = charactersEN.indexOf(
@@ -116,10 +122,5 @@ export async function getServerSideProps({ req, res, locale }) {
 }
 
 Character.getLayout = function getLayout(page) {
-  const character = page.props.character;
-  const getBreadcrumbs = (path) => {
-    console.log("PATH", path);
-    return path.split("/").filter((x) => x);
-  };
-  return <Layout getBreadcrumbs={getBreadcrumbs}>{page}</Layout>;
+  return <Layout>{page}</Layout>;
 };


### PR DESCRIPTION
https://github.com/enstars/makotools/issues/1

For character page (URL is ID but breadcrumbs show human readable name):
![Screen Shot 2022-07-21 at 11 38 49 PM](https://user-images.githubusercontent.com/19670297/180357659-88668887-55ca-429a-b0cb-a69b3e1d1116.png)


For card page:
![Screen Shot 2022-07-21 at 11 39 12 PM](https://user-images.githubusercontent.com/19670297/180357713-0a0c2c4c-d7e1-497b-9157-ea3888a29ff2.png)
