### PR TITLE
Fixed bugs relating to cards

### DIFF
--- a/components/core/CardStatsNumber.jsx
+++ b/components/core/CardStatsNumber.jsx
@@ -1,28 +1,30 @@
 import { useRouter } from "next/router";
 
 function getLocalizedNumber(number, locale, short = false) {
-  let ReactGlobalize = require("react-globalize");
-  let Globalize = require("globalize");
-  let FormatNumber = ReactGlobalize.FormatNumber;
+  if (!isNaN(number)) {
+    let ReactGlobalize = require("react-globalize");
+    let Globalize = require("globalize");
+    let FormatNumber = ReactGlobalize.FormatNumber;
 
-  Globalize.load(
-    require("cldr-data/supplemental/likelySubtags"),
-    require("cldr-data/supplemental/numberingSystems"),
-    require("cldr-data/supplemental/plurals"),
-    require("cldr-data/supplemental/ordinals"),
-    require(`cldr-data/main/${locale}/numbers`),
-    require(`cldr-data/main/${locale}/units`)
-  );
+    Globalize.load(
+      require("cldr-data/supplemental/likelySubtags"),
+      require("cldr-data/supplemental/numberingSystems"),
+      require("cldr-data/supplemental/plurals"),
+      require("cldr-data/supplemental/ordinals"),
+      require(`cldr-data/main/${locale}/numbers`),
+      require(`cldr-data/main/${locale}/units`)
+    );
 
-  return Globalize(locale).numberFormatter(
-    short
-      ? {
-          compact: "short",
-          minimumSignificantDigits: number > 99999 ? 3 : 2,
-          maximumSignificantDigits: number > 99999 ? 3 : 2,
-        }
-      : {}
-  )(number);
+    return Globalize(locale).numberFormatter(
+      short
+        ? {
+            compact: "short",
+            minimumSignificantDigits: number > 99999 ? 3 : 2,
+            maximumSignificantDigits: number > 99999 ? 3 : 2,
+          }
+        : {}
+    )(number);
+  }
 }
 
 function CardStatsNumber({ children, short = false }) {

--- a/components/core/CardStatsNumber.jsx
+++ b/components/core/CardStatsNumber.jsx
@@ -24,6 +24,8 @@ function getLocalizedNumber(number, locale, short = false) {
           }
         : {}
     )(number);
+  } else {
+    return number;
   }
 }
 

--- a/pages/cards/Card/Stats.jsx
+++ b/pages/cards/Card/Stats.jsx
@@ -76,7 +76,7 @@ function BigData({ data, label }) {
   );
 }
 
-function sumStats(stats, fallback = 0) {
+function sumStats(stats, fallback = "?") {
   const sum = stats?.da + stats?.vo + stats?.pf;
   if (!stats?.da) return fallback;
   return sum;
@@ -140,8 +140,6 @@ function Stats({ card }) {
             </thead>
             <tbody>
               {["min", "max", "ir", "ir1", "ir2", "ir3", "ir4"].map((p) => {
-                console.log(p, typeof p);
-                console.log(card.main);
                 if (card.main.stats?.[p]) {
                   const { da, vo, pf } = card.main.stats?.[p];
                   const sum = da + vo + pf;
@@ -173,19 +171,19 @@ function Stats({ card }) {
         <BigData
           label="Max stats (1 copy)"
           data={
-            <CardStatsNumber>{sumStats(card.main.stats?.ir) > 0 ? sumStats(card.main.stats?.ir) : "???"}</CardStatsNumber>
+            <CardStatsNumber>{sumStats(card.main.stats?.ir)}</CardStatsNumber>
           }
         />
         <BigData
           label="Max stats (3 copies)"
           data={
-            <CardStatsNumber>{sumStats(card.main.stats?.ir2) > 0 ? sumStats(card.main.stats?.ir2) : "???"}</CardStatsNumber>
+            <CardStatsNumber>{sumStats(card.main.stats?.ir2)}</CardStatsNumber>
           }
         />
         <BigData
           label="Max stats (5 copies)"
           data={
-            <CardStatsNumber>{sumStats(card.main.stats?.ir4) > 0 ? sumStats(card.main.stats?.ir4) : "???"}</CardStatsNumber>
+            <CardStatsNumber>{sumStats(card.main.stats?.ir4)}</CardStatsNumber>
           }
         />
       </Group>

--- a/pages/cards/Card/Stats.jsx
+++ b/pages/cards/Card/Stats.jsx
@@ -140,7 +140,7 @@ function Stats({ card }) {
             </thead>
             <tbody>
               {["min", "max", "ir", "ir1", "ir2", "ir3", "ir4"].map((p) => {
-                if (card.main.stats?.[p]) {
+                if (card.main.stats?.[p]?.da) {
                   const { da, vo, pf } = card.main.stats?.[p];
                   const sum = da + vo + pf;
                   return (

--- a/pages/cards/Card/Stats.jsx
+++ b/pages/cards/Card/Stats.jsx
@@ -76,7 +76,7 @@ function BigData({ data, label }) {
   );
 }
 
-function sumStats(stats, fallback = "?") {
+function sumStats(stats, fallback = 0) {
   const sum = stats?.da + stats?.vo + stats?.pf;
   if (!stats?.da) return fallback;
   return sum;
@@ -140,7 +140,9 @@ function Stats({ card }) {
             </thead>
             <tbody>
               {["min", "max", "ir", "ir1", "ir2", "ir3", "ir4"].map((p) => {
-                if (card.main.stats?.[p].da) {
+                console.log(p, typeof p);
+                console.log(card.main);
+                if (card.main.stats?.[p]) {
                   const { da, vo, pf } = card.main.stats?.[p];
                   const sum = da + vo + pf;
                   return (
@@ -171,19 +173,19 @@ function Stats({ card }) {
         <BigData
           label="Max stats (1 copy)"
           data={
-            <CardStatsNumber>{sumStats(card.main.stats?.ir)}</CardStatsNumber>
+            <CardStatsNumber>{sumStats(card.main.stats?.ir) > 0 ? sumStats(card.main.stats?.ir) : "???"}</CardStatsNumber>
           }
         />
         <BigData
           label="Max stats (3 copies)"
           data={
-            <CardStatsNumber>{sumStats(card.main.stats?.ir2)}</CardStatsNumber>
+            <CardStatsNumber>{sumStats(card.main.stats?.ir2) > 0 ? sumStats(card.main.stats?.ir2) : "???"}</CardStatsNumber>
           }
         />
         <BigData
           label="Max stats (5 copies)"
           data={
-            <CardStatsNumber>{sumStats(card.main.stats?.ir4)}</CardStatsNumber>
+            <CardStatsNumber>{sumStats(card.main.stats?.ir4) > 0 ? sumStats(card.main.stats?.ir4) : "???"}</CardStatsNumber>
           }
         />
       </Group>

--- a/pages/cards/[id].page.jsx
+++ b/pages/cards/[id].page.jsx
@@ -195,17 +195,17 @@ export const getServerSideProps = getServerSideUser(
             image1: `card_rectangle4_${cardID}_normal.png`,
             image2: `card_rectangle4_${cardID}_evolution.png`,
             stats1: getLocalizedNumber(
-              sumStats(card.main.stats.ir, 0),
+              sumStats(card.main.stats.ir, "???"),
               locale,
               false
             ),
             stats2: getLocalizedNumber(
-              sumStats(card.main.stats.ir2, 0),
+              sumStats(card.main.stats.ir2, "???"),
               locale,
               false
             ),
             stats3: getLocalizedNumber(
-              sumStats(card.main.stats.ir4, 0),
+              sumStats(card.main.stats.ir4, "???"),
               locale,
               false
             ),

--- a/pages/cards/[id].page.jsx
+++ b/pages/cards/[id].page.jsx
@@ -195,17 +195,17 @@ export const getServerSideProps = getServerSideUser(
             image1: `card_rectangle4_${cardID}_normal.png`,
             image2: `card_rectangle4_${cardID}_evolution.png`,
             stats1: getLocalizedNumber(
-              sumStats(card.main.stats.ir, "???"),
+              sumStats(card.main.stats.ir, 0),
               locale,
               false
             ),
             stats2: getLocalizedNumber(
-              sumStats(card.main.stats.ir2, "???"),
+              sumStats(card.main.stats.ir2, 0),
               locale,
               false
             ),
             stats3: getLocalizedNumber(
-              sumStats(card.main.stats.ir4, "???"),
+              sumStats(card.main.stats.ir4, 0),
               locale,
               false
             ),


### PR DESCRIPTION
The site would crash whenever I clicked on a card, which was because the fallback value for a missing piece of data was set to a string instead of an integer. 