### PR TITLE
V0.5.3

### DIFF
--- a/components/Homepage/CurrentScoutsCountdown.tsx
+++ b/components/Homepage/CurrentScoutsCountdown.tsx
@@ -58,7 +58,6 @@ function Countdown({ endDate }: { endDate: string }) {
 
 function ScoutCard({ scout }: { scout: Scout }) {
   const { t } = useTranslation("home");
-  const { classes } = useStyles();
   return (
     <Paper
       withBorder
@@ -81,11 +80,7 @@ function ScoutCard({ scout }: { scout: Scout }) {
         />
         <Stack>
           <Group>
-            <Title order={4}>
-              {scout.type === "scout"
-                ? t("scout.scout", { name: scout.name[0] })
-                : t("scout.fs", { name: scout.name[0] })}
-            </Title>
+            <Title order={4}>{t("scout.fs", { name: scout.name[0] })}</Title>
             <Badge
               variant="filled"
               color={scout.type === "scout" ? "violet" : "lightblue"}

--- a/components/Homepage/CurrentScoutsCountdown.tsx
+++ b/components/Homepage/CurrentScoutsCountdown.tsx
@@ -105,9 +105,11 @@ function CurrentScoutsCards({ scouts }: { scouts: Scout[] }) {
 
   return (
     <SimpleGrid
-      cols={scouts.length}
       className={classes.scoutsCards}
-      breakpoints={[{ maxWidth: 755, cols: 1, spacing: "sm" }]}
+      breakpoints={[
+        { maxWidth: 755, cols: 1, spacing: "sm" },
+        { minWidth: 755, cols: 2, spacing: "sm" },
+      ]}
     >
       {scouts.map((scout: Scout) => (
         <ScoutCard key={scout.gacha_id} scout={scout} />

--- a/data/skills.ts
+++ b/data/skills.ts
@@ -450,6 +450,17 @@ const supportSkills = {
     4: [],
     5: [[25], [35], [50], [65], [75]],
   },
+  24: {
+    id: 24,
+    daydream_name: "PieceUpGrowthTicket",
+    drop_type: "growth ticket",
+    drop: "growthTicket",
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [[1.25], [1.35], [1.5], [1.65], [1.75]],
+  },
   28: {
     id: 28,
     daydream_name: "PieceUpAllAll",

--- a/locales/en/campaigns.json
+++ b/locales/en/campaigns.json
@@ -7,9 +7,11 @@
       "special": "Special Event"
     },
     "scout": {
-      "scout": "Event Scout",
+      "scout": "Theme Scout",
       "feature": "Feature Scout",
-      "feature scout": "Feature Scout"
+      "feature scout": "Feature Scout",
+      "original": "Original Scout",
+      "anniv": "Anniversary Scout"
     },
     "others": {
       "birthday": "Birthday Campaign",
@@ -25,9 +27,11 @@
       "special": "Special"
     },
     "scout": {
-      "scout": "Event",
+      "scout": "Theme",
       "feature": "Feature",
-      "feature scout": "Feature"
+      "feature scout": "Feature",
+      "original": "Global",
+      "anniv": "Anniversary"
     },
     "others": {
       "birthday": "Birthday",

--- a/locales/en/game__campaignTypes.json
+++ b/locales/en/game__campaignTypes.json
@@ -2,9 +2,11 @@
   "song": "Unit Song Event",
   "tour": "Tour Event",
   "shuffle": "Shuffle Event",
-  "scout": "Scout",
+  "scout": "Theme Scout",
   "feature scout": "Featured Scout",
   "birthday": "Birthday",
   "anniversary": "Anniversary",
+  "anniv": "Anniversary Scout",
+  "original": "Global Scout",
   "other": "Other"
 }

--- a/locales/en/scouts.json
+++ b/locales/en/scouts.json
@@ -10,6 +10,6 @@
   "past": "Past",
   "ongoing": "Ongoing",
   "scout": {
-    "dateUnknown": "Scout date for this region unknown"
+    "dateUnknown": "Scout date for this region is unknown"
   }
 }

--- a/locales/en/skills.json
+++ b/locales/en/skills.json
@@ -16,6 +16,7 @@
     "type_4": "Increases the amount that the Ensemble Time Gauge rises after a Good/Great/Perfect.",
     "type_29": "During Ensemble Live: Increases the drop rate of all Stat Pieces by {{percent}}%",
     "type_30": "Increases the drop rate of Idol Pieces by {{percent}}%.",
+    "type_24": "Increase the drop rate of Growth Tickets by {{percent}}x",
     "type_generic": "Increases the drop rate of {{type}} stat pieces by {{percent}}%.",
     "pieceNames": {
       "smallRed": "small red",

--- a/pages/calendar/components/CalendarListEventCard.tsx
+++ b/pages/calendar/components/CalendarListEventCard.tsx
@@ -7,6 +7,7 @@ import {
   IconExclamationMark,
   IconPlayerPlay,
   IconShirt,
+  IconWorld,
 } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 import Link from "next/link";
@@ -99,19 +100,22 @@ function CalendarListEventCard({
                 ? "lightblue"
                 : event.type === "scout"
                 ? "violet"
+                : event.type === "original"
+                ? "green"
                 : "yellow"
             }
-            sx={(theme) => ({})}
             leftSection={
               <Box mt={4}>
-                {event.type === "birthday" ? (
+                {event.type === "birthday" || event.type === "anniv" ? (
                   <IconCake size={12} strokeWidth={3} />
                 ) : event.type === "feature scout" ? (
                   <IconShirt size={12} strokeWidth={3} />
                 ) : event.type === "scout" ? (
                   <IconDiamond size={12} strokeWidth={3} />
-                ) : event.type === "song" ? (
+                ) : event.type === "song" || event.type === "shuffle" ? (
                   <IconAward size={12} strokeWidth={3} />
+                ) : event.type === "original" ? (
+                  <IconWorld size={12} strokeWidth={3} />
                 ) : (
                   <IconBus size={12} strokeWidth={3} />
                 )}

--- a/pages/scouts/index.page.tsx
+++ b/pages/scouts/index.page.tsx
@@ -104,7 +104,8 @@ function Page({
           label: t("startDate"),
           value: "date",
           function: (a: Scout, b: Scout) =>
-            dayjs(a.start.en).unix() - dayjs(b.start.en).unix(),
+            dayjs(a.start[viewOptions.region]).unix() -
+            dayjs(b.start[viewOptions.region]).unix(),
         },
       ],
       baseSort: "id",
@@ -243,7 +244,7 @@ function Page({
                     },
                   }));
                 }}
-                spacing={3}
+                spacing={4}
               >
                 {[
                   {
@@ -269,6 +270,30 @@ function Page({
                       >
                         <IconComet size={16} />
                         {t("campaigns:full.scout.feature")}
+                      </Group>
+                    ),
+                  },
+                  {
+                    value: "original",
+                    label: (
+                      <Group
+                        align="center"
+                        spacing={6}
+                        sx={{ display: "inline-flex" }}
+                      >
+                        {t("campaigns:full.scout.original")}
+                      </Group>
+                    ),
+                  },
+                  {
+                    value: "anniv",
+                    label: (
+                      <Group
+                        align="center"
+                        spacing={6}
+                        sx={{ display: "inline-flex" }}
+                      >
+                        {t("campaigns:full.scout.anniv")}
                       </Group>
                     ),
                   },

--- a/services/skills.ts
+++ b/services/skills.ts
@@ -106,6 +106,7 @@ export function supportSkillParse(
         return t(`skills:support.type_${typeId}`, {
           count,
         });
+      case 24:
       case 29:
       case 30:
         return t(`skills:support.type_${typeId}`, {

--- a/types/game.d.ts
+++ b/types/game.d.ts
@@ -235,6 +235,7 @@ type SupportSkillIDs =
   | 14
   | 15
   | 16
+  | 24
   | 28
   | 29
   | 30;

--- a/types/game.d.ts
+++ b/types/game.d.ts
@@ -307,7 +307,7 @@ interface GameCardOld {
 }
 
 export type EventType = "song" | "tour" | "shuffle" | "special";
-export type ScoutType = "scout" | "feature scout";
+export type ScoutType = "scout" | "feature scout" | "original" | "anniv";
 type CampaignType =
   | "birthday"
   | "anniversary"


### PR DESCRIPTION
- improve scouts countdown layout on homepage
- remove scout! prefix from theme scouts on homepage
- fix sort by date on the scout page so it aligns with the current region's dates rather than the english server's dates
- add a missing skill type for cards